### PR TITLE
Fix issue #5: eslint fails to load config standard

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
-	"name": "client",
-	"version": "1.8.0",
+	"name": "healthier-client",
+	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
Fix issue #5

Looks like issue is related to eslint originally:
https://eslint.org/docs/user-guide/migrating-to-6.0.0#package-loading-simplification

I changed options for `CLIEngine`, so now it lints with working directory.